### PR TITLE
Simplify fullscreen/maximize logic

### DIFF
--- a/include/sycamore/desktop/view.h
+++ b/include/sycamore/desktop/view.h
@@ -87,10 +87,10 @@ void view_move_to(struct sycamore_view *view, int x, int y);
 struct sycamore_output *view_get_main_output(struct sycamore_view *view);
 
 void view_set_fullscreen(struct sycamore_view *view,
-        const struct wlr_box *full_box, bool fullscreen);
+        const struct sycamore_output *output, bool fullscreen);
 
 void view_set_maximized(struct sycamore_view *view,
-        const struct wlr_box *max_box, bool maximized);
+        const struct sycamore_output *output, bool maximized);
 
 void view_set_focus(struct sycamore_view *view);
 

--- a/include/sycamore/desktop/view.h
+++ b/include/sycamore/desktop/view.h
@@ -94,6 +94,8 @@ void view_set_maximized(struct sycamore_view *view,
 
 void view_set_focus(struct sycamore_view *view);
 
+void view_set_to_output_center(struct sycamore_view *view, struct sycamore_output *output);
+
 void view_ptr_connect(struct view_ptr *ptr, struct sycamore_view *view);
 
 void view_ptr_disconnect(struct view_ptr *ptr);

--- a/include/sycamore/input/cursor.h
+++ b/include/sycamore/input/cursor.h
@@ -57,7 +57,7 @@ void cursor_set_image_surface(struct sycamore_cursor *cursor,
 
 void output_setup_xcursor(struct sycamore_cursor *cursor, struct sycamore_output *output);
 
-struct wlr_output *cursor_at_output(struct sycamore_cursor *cursor,
+struct sycamore_output *cursor_at_output(struct sycamore_cursor *cursor,
         struct wlr_output_layout *layout);
 
 struct sycamore_cursor *sycamore_cursor_create(struct sycamore_seat *seat,

--- a/include/sycamore/output/output.h
+++ b/include/sycamore/output/output.h
@@ -17,7 +17,7 @@ struct sycamore_output {
 
 void handle_backend_new_output(struct wl_listener *listener, void *data);
 
-void output_get_center_coords(struct sycamore_output *output, struct wlr_fbox *box);
+void output_get_center_coords(struct sycamore_output *output, struct wlr_box *box);
 
 void sycamore_output_destroy(struct sycamore_output *output);
 

--- a/sycamore/desktop/shell/xdg_shell.c
+++ b/sycamore/desktop/shell/xdg_shell.c
@@ -37,42 +37,31 @@ static void handle_xdg_shell_view_request_fullscreen(struct wl_listener *listene
     struct sycamore_xdg_shell_view *view = wl_container_of(listener, view, request_fullscreen);
     struct sycamore_view *base = &view->base_view;
     bool fullscreen = view->xdg_toplevel->requested.fullscreen;
+    struct sycamore_output *output = NULL;
+
     if (fullscreen) {
-        /* If there is a fullscreen_output, satisfy it first */
-        struct wlr_output *output = view->xdg_toplevel->requested.fullscreen_output;
-        if (!output) {
-            struct sycamore_output *sycamore_output = view_get_main_output(base);
-            if (sycamore_output) {
-                output = sycamore_output->wlr_output;
-            }
+        struct wlr_output *fullscreen_output = view->xdg_toplevel->requested.fullscreen_output;
+        if (fullscreen_output && fullscreen_output->data) {
+            output = fullscreen_output->data;
+        } else {
+            output = view_get_main_output(base);
         }
-
-        /* output may still be NULL, but we apply it anyway */
-        struct wlr_box box;
-        wlr_output_layout_get_box(server.output_layout, output, &box);
-
-        view_set_fullscreen(base, &box, fullscreen);
-    } else {
-        view_set_fullscreen(base, NULL, fullscreen);
     }
+
+    view_set_fullscreen(base, output, fullscreen);
 }
 
 static void handle_xdg_shell_view_request_maximize(struct wl_listener *listener, void *data) {
     struct sycamore_xdg_shell_view *view = wl_container_of(listener, view, request_maximize);
     struct sycamore_view *base = &view->base_view;
     bool maximized = view->xdg_toplevel->requested.maximized;
+    struct sycamore_output *output = NULL;
+
     if (maximized) {
-        struct sycamore_output *output = view_get_main_output(base);
-        if (output) {
-            view_set_maximized(base, &output->usable_area, maximized);
-        } else {
-            struct wlr_box box;
-            wlr_output_layout_get_box(server.output_layout, NULL, &box);
-            view_set_maximized(base, &box, maximized);
-        }
-    } else {
-        view_set_maximized(base, NULL, maximized);
+        output = view_get_main_output(base);
     }
+
+    view_set_maximized(base, output, maximized);
 }
 
 static void handle_xdg_shell_view_request_minimize(struct wl_listener *listener, void *data) {

--- a/sycamore/desktop/view.c
+++ b/sycamore/desktop/view.c
@@ -32,11 +32,7 @@ void view_map(struct sycamore_view *view,
 
     struct sycamore_output *output = cursor_at_output(server.seat->cursor, server.output_layout);
 
-    if (output) {
-        struct wlr_box box;
-        wlr_output_layout_get_box(server.output_layout, output->wlr_output, &box);
-        view_move_to(view, box.x, box.y);
-    }
+    view_set_to_output_center(view, output);
 
     view_set_maximized(view, output, maximized);
 
@@ -224,6 +220,23 @@ void view_set_maximized(struct sycamore_view *view,
     view->interface->set_size(view, max_box.width, max_box.height);
     view->is_maximized = maximized;
     view->interface->set_maximized(view, maximized);
+}
+
+void view_set_to_output_center(struct sycamore_view *view, struct sycamore_output *output) {
+    if (!output) {
+        return;
+    }
+
+    struct wlr_box center;
+    output_get_center_coords(output, &center);
+
+    struct wlr_box view_box;
+    view->interface->get_geometry(view, &view_box);
+
+    view_box.x = center.x - (view_box.width / 2);
+    view_box.y = center.y - (view_box.height / 2);
+
+    view_move_to(view, view_box.x, view_box.y);
 }
 
 void view_ptr_connect(struct view_ptr *ptr, struct sycamore_view *view) {

--- a/sycamore/input/cursor.c
+++ b/sycamore/input/cursor.c
@@ -154,13 +154,15 @@ void output_setup_xcursor(struct sycamore_cursor *cursor, struct sycamore_output
     xcursor_reset(cursor);
 }
 
-struct wlr_output *cursor_at_output(struct sycamore_cursor *cursor,
+struct sycamore_output *cursor_at_output(struct sycamore_cursor *cursor,
         struct wlr_output_layout *layout) {
     struct wlr_cursor *wlr_cursor = cursor->wlr_cursor;
-    struct wlr_output *output = wlr_output_layout_output_at(layout,
-            wlr_cursor->x, wlr_cursor->y);
+    struct wlr_output *output = wlr_output_layout_output_at(layout, wlr_cursor->x, wlr_cursor->y);
+    if (!output) {
+        return NULL;
+    }
 
-    return output;
+    return output->data;
 }
 
 static void handle_cursor_motion(struct wl_listener *listener, void *data) {

--- a/sycamore/input/cursor.c
+++ b/sycamore/input/cursor.c
@@ -79,7 +79,7 @@ void cursor_disable(struct sycamore_cursor *cursor) {
 
 void cursor_warp_to_output_center(struct sycamore_cursor *cursor, struct sycamore_output *output) {
     struct wlr_cursor *wlr_cursor = cursor->wlr_cursor;
-    struct wlr_fbox box;
+    struct wlr_box box;
     output_get_center_coords(output, &box);
     wlr_cursor_warp(wlr_cursor, NULL, box.x, box.y);
 }
@@ -145,7 +145,7 @@ void output_setup_xcursor(struct sycamore_cursor *cursor, struct sycamore_output
 
     /* If this is the first output, cursor should be in the center of it*/
     if (wl_list_length(&server.all_outputs) == 1) {
-        struct wlr_fbox box;
+        struct wlr_box box;
         output_get_center_coords(output, &box);
         cursor->wlr_cursor->x = box.x;
         cursor->wlr_cursor->y = box.y;

--- a/sycamore/output/output.c
+++ b/sycamore/output/output.c
@@ -56,13 +56,12 @@ struct sycamore_output *sycamore_output_create(struct wlr_output *wlr_output) {
     return output;
 }
 
-void output_get_center_coords(struct sycamore_output *output, struct wlr_fbox *box) {
-    struct wlr_box output_box;
+void output_get_center_coords(struct sycamore_output *output, struct wlr_box *box) {
     wlr_output_layout_get_box(server.output_layout,
-                              output->wlr_output, &output_box);
+                              output->wlr_output, box);
 
-    box->x = output_box.x + output_box.width / 2.0;
-    box->y = output_box.y + output_box.height / 2.0;
+    box->x += (box->width / 2);
+    box->y += (box->height / 2);
 }
 
 struct wlr_output_mode *output_max_mode(struct wlr_output *output) {


### PR DESCRIPTION
* Fullscreen/maximize logic cleanup.
* View is mapped to the output center by default.