### PR TITLE
Refactor cursor disabled state as a seatop mode

### DIFF
--- a/include/sycamore/input/cursor.h
+++ b/include/sycamore/input/cursor.h
@@ -12,14 +12,19 @@
 struct sycamore_output;
 struct sycamore_seat;
 
+enum cursor_image_mode {
+    HIDDEN,
+    IMAGE,
+    SURFACE,
+};
+
 struct sycamore_cursor {
     struct wlr_cursor *wlr_cursor;
     struct wlr_xcursor_manager *xcursor_manager;
     struct wlr_pointer_gestures_v1 *gestures;
 
-    bool enabled;
-
-    const char *image;
+    enum cursor_image_mode image_mode;
+    const char *image; // image name for IMAGE mode
 
     size_t pressed_button_count;
 
@@ -41,23 +46,19 @@ struct sycamore_cursor {
     struct sycamore_seat *seat;
 };
 
-/* This will avoid setting duplicate image. Pass NULL to clear cursor image. */
+void cursor_set_hidden(struct sycamore_cursor *cursor);
+
+/* This will avoid setting duplicate image. If image is NULL, hide cursor. */
 void cursor_set_image(struct sycamore_cursor *cursor, const char *image);
 
+/* If surface is NULL, hide cursor. */
 void cursor_set_image_surface(struct sycamore_cursor *cursor,
         struct wlr_surface *surface, int32_t hotspot_x, int32_t hotspot_y);
 
-void cursor_rebase(struct sycamore_cursor *cursor);
-
-void cursor_enable(struct sycamore_cursor *cursor);
-
-void cursor_disable(struct sycamore_cursor *cursor);
+void cursor_warp(struct sycamore_cursor *cursor, double lx, double ly);
 
 /* Warp cursor again and refresh image. */
 void cursor_refresh(struct sycamore_cursor *cursor);
-
-/* Center cursor on this output. */
-void cursor_set_to_output(struct sycamore_cursor *cursor, struct sycamore_output *output);
 
 struct sycamore_output *cursor_at_output(struct sycamore_cursor *cursor,
         struct wlr_output_layout *layout);

--- a/include/sycamore/output/output.h
+++ b/include/sycamore/output/output.h
@@ -16,6 +16,9 @@ struct sycamore_output {
     struct wl_listener frame;
 };
 
+/* Center cursor on this output. */
+void output_ensure_cursor(struct sycamore_output *output, struct sycamore_cursor *cursor);
+
 void sycamore_output_destroy(struct sycamore_output *output);
 
 struct sycamore_output *sycamore_output_create(struct wlr_output *wlr_output);

--- a/sycamore/desktop/layer.c
+++ b/sycamore/desktop/layer.c
@@ -29,7 +29,7 @@ void layer_map(struct sycamore_layer *layer) {
 
     layer->mapped = true;
 
-    cursor_rebase(seat->cursor);
+    seatop_pointer_rebase(seat);
 }
 
 void layer_unmap(struct sycamore_layer *layer) {
@@ -49,7 +49,7 @@ void layer_unmap(struct sycamore_layer *layer) {
 
     layer->mapped = false;
 
-    cursor_rebase(seat->cursor);
+    seatop_pointer_rebase(seat);
 }
 
 void layer_surface_commit(struct sycamore_layer *layer) {

--- a/sycamore/desktop/shell/xdg_shell.c
+++ b/sycamore/desktop/shell/xdg_shell.c
@@ -18,7 +18,7 @@ static void handle_xdg_shell_view_request_move(struct wl_listener *listener, voi
      * client, to prevent the client from requesting this whenever they want. */
     struct sycamore_xdg_shell_view *view = wl_container_of(listener, view, request_move);
     struct sycamore_view *base = &view->base_view;
-    seatop_begin_pointer_move(server.seat, base);
+    seatop_pointer_begin_move(server.seat, base);
 }
 
 static void handle_xdg_shell_view_request_resize(struct wl_listener *listener, void *data) {
@@ -30,7 +30,7 @@ static void handle_xdg_shell_view_request_resize(struct wl_listener *listener, v
     struct sycamore_xdg_shell_view *view = wl_container_of(listener, view, request_resize);
     struct sycamore_view *base = &view->base_view;
     struct wlr_xdg_toplevel_resize_event *event = data;
-    seatop_begin_pointer_resize(server.seat, base, event->edges);
+    seatop_pointer_begin_resize(server.seat, base, event->edges);
 }
 
 static void handle_xdg_shell_view_request_fullscreen(struct wl_listener *listener, void *data) {

--- a/sycamore/desktop/view.c
+++ b/sycamore/desktop/view.c
@@ -52,7 +52,7 @@ void view_map(struct sycamore_view *view,
 
     view_set_focus(view);
 
-    cursor_rebase(server.seat->cursor);
+    seatop_pointer_rebase(server.seat);
 }
 
 void view_unmap(struct sycamore_view *view) {
@@ -71,7 +71,7 @@ void view_unmap(struct sycamore_view *view) {
 
     view->mapped = false;
 
-    cursor_rebase(server.seat->cursor);
+    seatop_pointer_rebase(server.seat);
 }
 
 void view_destroy(struct sycamore_view *view) {

--- a/sycamore/input/keybinding.c
+++ b/sycamore/input/keybinding.c
@@ -58,7 +58,7 @@ static void cycle_view(struct sycamore_keybinding *keybinding) {
 
     struct sycamore_view *next_view = wl_container_of(server.mapped_views.prev, next_view, link);
     view_set_focus(next_view);
-    cursor_rebase(server.seat->cursor);
+    seatop_pointer_rebase(server.seat);
 }
 
 /* action */

--- a/sycamore/input/seat.c
+++ b/sycamore/input/seat.c
@@ -118,7 +118,7 @@ static void handle_start_drag(struct wl_listener *listener, void *data) {
         seat_drag_icon_update_position(seat, icon);
     }
 
-    seatop_begin_default(seat);
+    seatop_begin_pointer_passthrough(seat);
 }
 
 void seat_drag_icon_update_position(struct sycamore_seat *seat, struct sycamore_drag_icon *icon) {
@@ -383,7 +383,7 @@ struct sycamore_seat *sycamore_seat_create(struct wl_display *display, struct wl
         return NULL;
     }
 
-    seat->seatop_impl = NULL;
+    seat->seatop_pointer_impl = NULL;
     seat->focused_layer = NULL;
     wl_list_init(&seat->devices);
 
@@ -421,12 +421,12 @@ struct sycamore_seat *sycamore_seat_create(struct wl_display *display, struct wl
     wl_signal_add(&seat->wlr_seat->events.destroy,
                   &seat->destroy);
 
-    seatop_begin_default(seat);
+    seatop_begin_pointer_passthrough(seat);
 
     return seat;
 }
 
-bool seatop_interactive_check(struct sycamore_seat *seat, struct sycamore_view *view, enum seatop_mode mode) {
+bool seatop_pointer_interactive_check(struct sycamore_seat *seat, struct sycamore_view *view, enum seatop_pointer_mode mode) {
     /* This fuction is used for checking whether an
      * 'interactive' seatop mode should begin. including:
      *
@@ -435,16 +435,16 @@ bool seatop_interactive_check(struct sycamore_seat *seat, struct sycamore_view *
      */
 
     // Don't renter.
-    if (seat->seatop_impl->mode == mode) {
+    if (seat->seatop_pointer_impl->mode == mode) {
         return false;
     }
 
-    // Deny move/resize from maximized/fullscreen clients.
+    // Deny move/resize from maximized/fullscreen view.
     if (view->is_maximized || view->is_fullscreen) {
         return false;
     }
 
-    // Deny move/resize from unfocused clients or there is no focused clients.
+    // Deny move/resize from unfocused view or there is no focused view.
     if (view != server.focused_view.view) {
         return false;
     }

--- a/sycamore/input/seat.c
+++ b/sycamore/input/seat.c
@@ -118,7 +118,7 @@ static void handle_start_drag(struct wl_listener *listener, void *data) {
         seat_drag_icon_update_position(seat, icon);
     }
 
-    seatop_begin_pointer_passthrough(seat);
+    seatop_pointer_begin_full(seat);
 }
 
 void seat_drag_icon_update_position(struct sycamore_seat *seat, struct sycamore_drag_icon *icon) {
@@ -203,9 +203,9 @@ void seat_update_capabilities(struct sycamore_seat *seat) {
 
     wlr_seat_set_capabilities(seat->wlr_seat, caps);
 
-    // Disable cursor if seat doesn't have pointer capability.
+    // Switch to seatop_pointer_no if seat doesn't have pointer capability.
     if ((caps & WL_SEAT_CAPABILITY_POINTER) == 0) {
-        cursor_disable(seat->cursor);
+        seatop_pointer_begin_no(seat, FULL);
     }
 }
 
@@ -356,7 +356,7 @@ void sycamore_seat_destroy(struct sycamore_seat *seat) {
         seat_device_destroy(seat_device);
     }
 
-    seatop_end(seat);
+    seatop_pointer_end(seat);
 
     wl_list_remove(&seat->destroy.link);
     wl_list_remove(&seat->request_set_cursor.link);
@@ -421,7 +421,7 @@ struct sycamore_seat *sycamore_seat_create(struct wl_display *display, struct wl
     wl_signal_add(&seat->wlr_seat->events.destroy,
                   &seat->destroy);
 
-    seatop_begin_pointer_passthrough(seat);
+    seatop_pointer_begin_no(seat, FULL);
 
     return seat;
 }

--- a/sycamore/input/seatop/seatop_pointer_blank.c
+++ b/sycamore/input/seatop/seatop_pointer_blank.c
@@ -1,0 +1,14 @@
+#include "sycamore/input/seat.h"
+
+static const struct seatop_pointer_impl impl = {
+        .mode = BLANK,
+};
+
+void seatop_pointer_begin_blank(struct sycamore_seat *seat, const char *cursor_image) {
+    seatop_pointer_end(seat);
+
+    seat->seatop_pointer_impl = &impl;
+
+    wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
+    cursor_set_image(seat->cursor, cursor_image);
+}

--- a/sycamore/input/seatop/seatop_pointer_down.c
+++ b/sycamore/input/seatop/seatop_pointer_down.c
@@ -2,19 +2,19 @@
 
 static void handle_surface_destroy(struct wl_listener *listener, void *data) {
     struct seatop_pointer_down_data *d = wl_container_of(listener, d, surface_destroy);
-    seatop_begin_pointer_passthrough(d->seat);
+    seatop_pointer_begin_full(d->seat);
 }
 
-static void process_pointer_button(struct sycamore_seat *seat, struct wlr_pointer_button_event *event) {
+static void process_button(struct sycamore_seat *seat, struct wlr_pointer_button_event *event) {
     wlr_seat_pointer_notify_button(seat->wlr_seat, event->time_msec,
                                    event->button, event->state);
 
     if (seat->cursor->pressed_button_count == 0) {
-        seatop_begin_pointer_passthrough(seat);
+        seatop_pointer_begin_full(seat);
     }
 }
 
-static void process_pointer_motion(struct sycamore_seat *seat, uint32_t time_msec) {
+static void process_motion(struct sycamore_seat *seat, uint32_t time_msec) {
     struct seatop_pointer_down_data *data = &(seat->seatop_pointer_data.down);
 
     double sx = data->dx + seat->cursor->wlr_cursor->x;
@@ -29,18 +29,18 @@ static void process_end(struct sycamore_seat *seat) {
 }
 
 static const struct seatop_pointer_impl impl = {
-        .pointer_button = process_pointer_button,
-        .pointer_motion = process_pointer_motion,
+        .button = process_button,
+        .motion = process_motion,
         .end = process_end,
-        .mode = SEATOP_POINTER_DOWN,
+        .mode = DOWN,
 };
 
-void seatop_begin_pointer_down(struct sycamore_seat *seat, struct wlr_surface *surface, double sx, double sy) {
+void seatop_pointer_begin_down(struct sycamore_seat *seat, struct wlr_surface *surface, double sx, double sy) {
     if (!surface) {
         return;
     }
 
-    seatop_end(seat);
+    seatop_pointer_end(seat);
 
     struct seatop_pointer_down_data *data = &(seat->seatop_pointer_data.down);
 

--- a/sycamore/input/seatop/seatop_pointer_down.c
+++ b/sycamore/input/seatop/seatop_pointer_down.c
@@ -2,7 +2,7 @@
 
 static void handle_surface_destroy(struct wl_listener *listener, void *data) {
     struct seatop_pointer_down_data *d = wl_container_of(listener, d, surface_destroy);
-    seatop_begin_default(d->seat);
+    seatop_begin_pointer_passthrough(d->seat);
 }
 
 static void process_pointer_button(struct sycamore_seat *seat, struct wlr_pointer_button_event *event) {
@@ -10,12 +10,12 @@ static void process_pointer_button(struct sycamore_seat *seat, struct wlr_pointe
                                    event->button, event->state);
 
     if (seat->cursor->pressed_button_count == 0) {
-        seatop_begin_default(seat);
+        seatop_begin_pointer_passthrough(seat);
     }
 }
 
 static void process_pointer_motion(struct sycamore_seat *seat, uint32_t time_msec) {
-    struct seatop_pointer_down_data *data = &(seat->pointer_down_data);
+    struct seatop_pointer_down_data *data = &(seat->seatop_pointer_data.down);
 
     double sx = data->dx + seat->cursor->wlr_cursor->x;
     double sy = data->dy + seat->cursor->wlr_cursor->y;
@@ -24,11 +24,11 @@ static void process_pointer_motion(struct sycamore_seat *seat, uint32_t time_mse
 }
 
 static void process_end(struct sycamore_seat *seat) {
-    struct seatop_pointer_down_data *data = &(seat->pointer_down_data);
+    struct seatop_pointer_down_data *data = &(seat->seatop_pointer_data.down);
     wl_list_remove(&data->surface_destroy.link);
 }
 
-static const struct sycamore_seatop_impl seatop_impl = {
+static const struct seatop_pointer_impl impl = {
         .pointer_button = process_pointer_button,
         .pointer_motion = process_pointer_motion,
         .end = process_end,
@@ -42,7 +42,7 @@ void seatop_begin_pointer_down(struct sycamore_seat *seat, struct wlr_surface *s
 
     seatop_end(seat);
 
-    struct seatop_pointer_down_data *data = &(seat->pointer_down_data);
+    struct seatop_pointer_down_data *data = &(seat->seatop_pointer_data.down);
 
     data->surface = surface;
     wl_signal_add(&surface->events.destroy, &data->surface_destroy);
@@ -51,5 +51,5 @@ void seatop_begin_pointer_down(struct sycamore_seat *seat, struct wlr_surface *s
     data->dy = sy - seat->cursor->wlr_cursor->y;
     data->seat = seat;
 
-    seat->seatop_impl = &seatop_impl;
+    seat->seatop_pointer_impl = &impl;
 }

--- a/sycamore/input/seatop/seatop_pointer_full.c
+++ b/sycamore/input/seatop/seatop_pointer_full.c
@@ -27,7 +27,7 @@ static inline void drag_icons_update_position(struct sycamore_seat *seat) {
     }
 }
 
-static void process_pointer_button(struct sycamore_seat *seat, struct wlr_pointer_button_event *event) {
+static void process_button(struct sycamore_seat *seat, struct wlr_pointer_button_event *event) {
     if (event->state == WLR_BUTTON_RELEASED) {
         wlr_seat_pointer_notify_button(seat->wlr_seat, event->time_msec, event->button, event->state);
         return;
@@ -41,29 +41,29 @@ static void process_pointer_button(struct sycamore_seat *seat, struct wlr_pointe
     view_set_focus(find_view_by_node(find_node(server.scene, cursor->x, cursor->y, &sx, &sy)));
 
     // Switch to seatop_pointer_down if seat has a focused surface.
-    seatop_begin_pointer_down(seat, state->focused_surface, state->sx, state->sy);
+    seatop_pointer_begin_down(seat, state->focused_surface, state->sx, state->sy);
 
     wlr_seat_pointer_notify_button(seat->wlr_seat, event->time_msec, event->button, event->state);
 }
 
-static void process_pointer_motion(struct sycamore_seat *seat, uint32_t time_msec) {
+static void process_motion(struct sycamore_seat *seat, uint32_t time_msec) {
     pointer_update(seat->cursor, time_msec);
     drag_icons_update_position(seat);
 }
 
-static void process_pointer_rebase(struct sycamore_seat *seat) {
+static void process_rebase(struct sycamore_seat *seat) {
     pointer_update(seat->cursor, get_current_time_msec());
 }
 
 static const struct seatop_pointer_impl impl = {
-        .pointer_button = process_pointer_button,
-        .pointer_motion = process_pointer_motion,
-        .pointer_rebase = process_pointer_rebase,
-        .mode = SEATOP_POINTER_PASSTHROUGH,
+        .button = process_button,
+        .motion = process_motion,
+        .rebase = process_rebase,
+        .mode = FULL,
 };
 
-void seatop_begin_pointer_passthrough(struct sycamore_seat *seat) {
-    seatop_end(seat);
+void seatop_pointer_begin_full(struct sycamore_seat *seat) {
+    seatop_pointer_end(seat);
     seat->seatop_pointer_impl = &impl;
-    cursor_rebase(seat->cursor);
+    pointer_update(seat->cursor, get_current_time_msec());
 }

--- a/sycamore/input/seatop/seatop_pointer_move.c
+++ b/sycamore/input/seatop/seatop_pointer_move.c
@@ -6,13 +6,13 @@ static void process_pointer_button(struct sycamore_seat *seat,
     if (seat->cursor->pressed_button_count == 0) {
         // If there is no button being pressed
         // we back to default.
-        seatop_begin_default(seat);
+        seatop_begin_pointer_passthrough(seat);
     }
 }
 
 static void process_pointer_motion(struct sycamore_seat *seat, uint32_t time_msec) {
     /* Move the grabbed view to the new position. */
-    struct seatop_pointer_move_data *data = &(seat->pointer_move_data);
+    struct seatop_pointer_move_data *data = &(seat->seatop_pointer_data.move);
     struct wlr_cursor *cursor = seat->cursor->wlr_cursor;
     struct sycamore_view *view = data->view_ptr.view;
     if (!view) {
@@ -28,13 +28,13 @@ static void process_pointer_rebase(struct sycamore_seat *seat) {
 }
 
 static void process_end(struct sycamore_seat *seat) {
-    struct seatop_pointer_move_data *data = &(seat->pointer_move_data);
+    struct seatop_pointer_move_data *data = &(seat->seatop_pointer_data.move);
     if (data->view_ptr.view) {
         view_ptr_disconnect(&data->view_ptr);
     }
 }
 
-static const struct sycamore_seatop_impl seatop_impl = {
+static const struct seatop_pointer_impl impl = {
         .pointer_button = process_pointer_button,
         .pointer_motion = process_pointer_motion,
         .pointer_rebase = process_pointer_rebase,
@@ -43,19 +43,19 @@ static const struct sycamore_seatop_impl seatop_impl = {
 };
 
 void seatop_begin_pointer_move(struct sycamore_seat *seat, struct sycamore_view *view) {
-    if (!seatop_interactive_check(seat, view, SEATOP_POINTER_MOVE)) {
+    if (!seatop_pointer_interactive_check(seat, view, SEATOP_POINTER_MOVE)) {
         return;
     }
 
     seatop_end(seat);
 
-    struct seatop_pointer_move_data *data = &(seat->pointer_move_data);
+    struct seatop_pointer_move_data *data = &(seat->seatop_pointer_data.move);
 
     view_ptr_connect(&data->view_ptr, view);
     data->dx = seat->cursor->wlr_cursor->x - view->x;
     data->dy = seat->cursor->wlr_cursor->y - view->y;
 
-    seat->seatop_impl = &seatop_impl;
+    seat->seatop_pointer_impl = &impl;
 
     cursor_rebase(seat->cursor);
 }

--- a/sycamore/input/seatop/seatop_pointer_move.c
+++ b/sycamore/input/seatop/seatop_pointer_move.c
@@ -1,16 +1,16 @@
 #include "sycamore/desktop/view.h"
 #include "sycamore/input/seat.h"
 
-static void process_pointer_button(struct sycamore_seat *seat,
+static void process_button(struct sycamore_seat *seat,
         struct wlr_pointer_button_event *event) {
     if (seat->cursor->pressed_button_count == 0) {
         // If there is no button being pressed
         // we back to default.
-        seatop_begin_pointer_passthrough(seat);
+        seatop_pointer_begin_full(seat);
     }
 }
 
-static void process_pointer_motion(struct sycamore_seat *seat, uint32_t time_msec) {
+static void process_motion(struct sycamore_seat *seat, uint32_t time_msec) {
     /* Move the grabbed view to the new position. */
     struct seatop_pointer_move_data *data = &(seat->seatop_pointer_data.move);
     struct wlr_cursor *cursor = seat->cursor->wlr_cursor;
@@ -22,11 +22,6 @@ static void process_pointer_motion(struct sycamore_seat *seat, uint32_t time_mse
     view_move_to(view, cursor->x - data->dx, cursor->y - data->dy);
 }
 
-static void process_pointer_rebase(struct sycamore_seat *seat) {
-    wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
-    cursor_set_image(seat->cursor, "grabbing");
-}
-
 static void process_end(struct sycamore_seat *seat) {
     struct seatop_pointer_move_data *data = &(seat->seatop_pointer_data.move);
     if (data->view_ptr.view) {
@@ -35,19 +30,18 @@ static void process_end(struct sycamore_seat *seat) {
 }
 
 static const struct seatop_pointer_impl impl = {
-        .pointer_button = process_pointer_button,
-        .pointer_motion = process_pointer_motion,
-        .pointer_rebase = process_pointer_rebase,
+        .button = process_button,
+        .motion = process_motion,
         .end = process_end,
-        .mode = SEATOP_POINTER_MOVE,
+        .mode = MOVE,
 };
 
-void seatop_begin_pointer_move(struct sycamore_seat *seat, struct sycamore_view *view) {
-    if (!seatop_pointer_interactive_check(seat, view, SEATOP_POINTER_MOVE)) {
+void seatop_pointer_begin_move(struct sycamore_seat *seat, struct sycamore_view *view) {
+    if (!seatop_pointer_interactive_check(seat, view, MOVE)) {
         return;
     }
 
-    seatop_end(seat);
+    seatop_pointer_end(seat);
 
     struct seatop_pointer_move_data *data = &(seat->seatop_pointer_data.move);
 
@@ -57,5 +51,6 @@ void seatop_begin_pointer_move(struct sycamore_seat *seat, struct sycamore_view 
 
     seat->seatop_pointer_impl = &impl;
 
-    cursor_rebase(seat->cursor);
+    wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
+    cursor_set_image(seat->cursor, "grabbing");
 }

--- a/sycamore/input/seatop/seatop_pointer_no.c
+++ b/sycamore/input/seatop/seatop_pointer_no.c
@@ -1,0 +1,49 @@
+#include "sycamore/input/seat.h"
+
+static void process_button(struct sycamore_seat *seat, struct wlr_pointer_button_event *event) {
+    struct seatop_pointer_no_data *data = &(seat->seatop_pointer_data.no);
+
+    switch (data->end_mode) {
+        case BLANK:
+            seatop_pointer_begin_blank(seat, "left_ptr");
+            break;
+        case FULL:
+            seatop_pointer_begin_full(seat);
+            break;
+        default:
+            break;
+    }
+}
+
+static void process_motion(struct sycamore_seat *seat, uint32_t time_msec) {
+    struct seatop_pointer_no_data *data = &(seat->seatop_pointer_data.no);
+
+    switch (data->end_mode) {
+        case BLANK:
+            seatop_pointer_begin_blank(seat, "left_ptr");
+            break;
+        case FULL:
+            seatop_pointer_begin_full(seat);
+            break;
+        default:
+            break;
+    }
+}
+
+static const struct seatop_pointer_impl impl = {
+        .button = process_button,
+        .motion = process_motion,
+        .mode = NO,
+};
+
+void seatop_pointer_begin_no(struct sycamore_seat *seat, enum seatop_pointer_mode end_mode) {
+    seatop_pointer_end(seat);
+
+    struct seatop_pointer_no_data *data = &(seat->seatop_pointer_data.no);
+    data->end_mode = end_mode;
+
+    seat->seatop_pointer_impl = &impl;
+
+    wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
+    cursor_set_hidden(seat->cursor);
+}

--- a/sycamore/input/seatop/seatop_pointer_passthrough.c
+++ b/sycamore/input/seatop/seatop_pointer_passthrough.c
@@ -55,15 +55,15 @@ static void process_pointer_rebase(struct sycamore_seat *seat) {
     pointer_update(seat->cursor, get_current_time_msec());
 }
 
-static const struct sycamore_seatop_impl seatop_impl = {
+static const struct seatop_pointer_impl impl = {
         .pointer_button = process_pointer_button,
         .pointer_motion = process_pointer_motion,
         .pointer_rebase = process_pointer_rebase,
-        .mode = SEATOP_DEFAULT,
+        .mode = SEATOP_POINTER_PASSTHROUGH,
 };
 
-void seatop_begin_default(struct sycamore_seat *seat) {
+void seatop_begin_pointer_passthrough(struct sycamore_seat *seat) {
     seatop_end(seat);
-    seat->seatop_impl = &seatop_impl;
+    seat->seatop_pointer_impl = &impl;
     cursor_rebase(seat->cursor);
 }


### PR DESCRIPTION
Cursor itself doesn't maintain enabled/disabled state anymore. Use seatop mode instead.